### PR TITLE
Update chart release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - name: Run chart-testing (lint)
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.8.0
         with:
           command: lint
           config: .github/ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,17 @@ on:
 #    paths:
 #      - 'charts/**'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -22,8 +25,8 @@ jobs:
       - name: Fetch history
         run: git fetch --prune
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_repo_url: https://helm.patbos.com
         env:
-          CR_TOKEN: '${{ secrets.CR_TOKEN }}'
+          CR_TOKEN: '${{ github.token }}'

--- a/charts/adsb-exchange/Chart.yaml
+++ b/charts/adsb-exchange/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adsb-exchange
 description: Pulls ModeS/BEAST information from the mikenye/piaware (or another host providing ModeS/BEAST data), and sends data to ADS-B Exchange
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "20201113"
 sources:
   - https://adsbexchange.com/how-to-feed/

--- a/charts/adsb-exchange/Chart.yaml
+++ b/charts/adsb-exchange/Chart.yaml
@@ -3,7 +3,7 @@ name: adsb-exchange
 description: Pulls ModeS/BEAST information from the mikenye/piaware (or another host providing ModeS/BEAST data), and sends data to ADS-B Exchange
 type: application
 version: 1.0.2
-appVersion: 20201113
+appVersion: "20201113"
 sources:
   - https://adsbexchange.com/how-to-feed/
   - https://github.com/mikenye/docker-adsbexchange

--- a/charts/adsbhub/Chart.yaml
+++ b/charts/adsbhub/Chart.yaml
@@ -3,7 +3,7 @@ name: adsbhub
 description: Pulls ModeS/BEAST information from a host or container providing ModeS/BEAST data, and sends data to ADSBHub
 type: application
 version: 1.0.0
-appVersion: 1.06
+appVersion: "1.06"
 sources:
   - https://www.adsbhub.org/
   - https://github.com/mikenye/docker-adsbhub

--- a/charts/adsbhub/Chart.yaml
+++ b/charts/adsbhub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adsbhub
 description: Pulls ModeS/BEAST information from a host or container providing ModeS/BEAST data, and sends data to ADSBHub
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.06"
 sources:
   - https://www.adsbhub.org/

--- a/charts/tar1090/Chart.yaml
+++ b/charts/tar1090/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tar1090/values.yaml
+++ b/charts/tar1090/values.yaml
@@ -6,11 +6,21 @@ beast:
   host: 127.0.0.1
   port: 30005
 
-#timelapse:
-#  enable: true
-#  interval: 10
-#  history: 48
+location:
+  latitude: ""
+  longitude: ""
 
+timelapse:
+  enable: false
+  interval: ""
+  history: ""
+
+mlat:
+  host: ""
+  port: ""
+
+title:
+  showPlaneCount: false
 
 replicaCount: 1
 


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions used by chart linting and release workflows.
- Use the built-in GitHub token for chart releases instead of the custom CR_TOKEN secret.
- Fix chart lint issues surfaced by newer tooling.

## Validation
- helm lint charts/*
- Parsed all workflow YAML files
- git diff --check