### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -30,3 +31,21 @@ jobs:
           charts_repo_url: https://helm.patbos.com
         env:
           CR_TOKEN: '${{ github.token }}'
+      - name: Publish charts to GHCR OCI registry
+        run: |
+          shopt -s nullglob
+          packages=(.cr-release-packages/*.tgz)
+
+          if [[ ${#packages[@]} -eq 0 ]]; then
+            echo "No chart packages found for OCI publishing."
+            exit 0
+          fi
+
+          echo "${{ github.token }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" \
+            --password-stdin
+
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          for package in "${packages[@]}"; do
+            helm push "$package" "oci://ghcr.io/${owner}/helm-charts"
+          done

--- a/README.md
+++ b/README.md
@@ -4,5 +4,13 @@
 
     helm repo add patbos https://helm.patbos.com
     helm repo update
- 
 
+## OCI charts
+
+Charts are also published to GitHub Container Registry as OCI artifacts.
+
+    helm install <release-name> oci://ghcr.io/patbos/helm-charts/<chart-name> --version <chart-version>
+
+Example:
+
+    helm install adsb-ultrafeeder oci://ghcr.io/patbos/helm-charts/adsb-ultrafeeder --version 1.0.1

--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Charts are also published to GitHub Container Registry as OCI artifacts.
 Example:
 
     helm install adsb-ultrafeeder oci://ghcr.io/patbos/helm-charts/adsb-ultrafeeder --version 1.0.1
+
+## Backfill old releases to OCI
+
+Existing GitHub Release chart packages can be pushed to GHCR with:
+
+    GITHUB_TOKEN=<token-with-packages-write> ./scripts/backfill-oci-charts.sh
+
+The script downloads existing `*.tgz` assets from GitHub Releases and pushes
+them to `oci://ghcr.io/patbos/helm-charts`.

--- a/scripts/backfill-oci-charts.sh
+++ b/scripts/backfill-oci-charts.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-patbos/helm-charts}"
+owner="${repo%%/*}"
+registry_owner="${owner,,}"
+destination="oci://ghcr.io/${registry_owner}/helm-charts"
+workdir="${TMPDIR:-/tmp}/helm-oci-backfill"
+
+mkdir -p "$workdir"
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN must be set to a token with packages:write permission" >&2
+  exit 1
+fi
+
+echo "$GITHUB_TOKEN" | helm registry login ghcr.io \
+  --username "$owner" \
+  --password-stdin
+
+gh release list --repo "$repo" --limit 1000 --json tagName -q '.[].tagName' |
+while read -r tag; do
+  [[ -n "$tag" ]] || continue
+
+  echo "Downloading chart packages from release $tag"
+  gh release download "$tag" \
+    --repo "$repo" \
+    --pattern '*.tgz' \
+    --dir "$workdir" \
+    --clobber
+done
+
+shopt -s nullglob
+packages=("$workdir"/*.tgz)
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "No chart packages found in GitHub releases" >&2
+  exit 1
+fi
+
+for package in "${packages[@]}"; do
+  echo "Pushing $package to $destination"
+  helm push "$package" "$destination"
+done


### PR DESCRIPTION
## Summary
- Publish packaged Helm charts to GHCR as OCI artifacts alongside the existing Helm repository release flow.
- Document OCI install syntax in the README.
- Add a script to backfill existing GitHub Release chart packages into GHCR.

## Validation
- Parsed all workflow YAML files
- bash -n scripts/backfill-oci-charts.sh
- git diff --check